### PR TITLE
update CI checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,10 +7,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: ^1.20
         id: go
 
       - name: Check out code into the Go module directory
@@ -23,23 +23,23 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: ^1.20
         id: go
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
       - name: Install gofumpt
-        run: go install mvdan.cc/gofumpt@v0.3.1
+        run: go install mvdan.cc/gofumpt@v0.4.0
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.2
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
       - name: Lint
         run: make lint

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ We also have a repository for common Go utilities: https://github.com/flashbots/
 
 ```bash
 go install mvdan.cc/gofumpt@latest
-go install honnef.co/go/tools/cmd/staticcheck@v0.3.1
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
+go install honnef.co/go/tools/cmd/staticcheck@v0.4.2
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 ```
 
 ### Test


### PR DESCRIPTION
## 📝 Summary

Update CI checks so they work. Versions are copied from `boost-relay` repo.

## ⛱ Motivation and Context

I used this template recently and CI checks were failing by default.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
