### PR TITLE
Avoids shadowing metrics package in httpserver/server.go

### DIFF
--- a/httpserver/handler.go
+++ b/httpserver/handler.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request) {
-	m := s.metrics.Float64Histogram(
+	m := s.metricsSrv.Float64Histogram(
 		"request_duration_api",
 		"API request handling duration",
 		metrics.UomMicroseconds,


### PR DESCRIPTION
## 📝 Summary

Avoids shadowing metrics package in `httpserver/server.go`.

## ⛱ Motivation and Context

I have to manually adjust this every time I clone from the template and I don't want to any more

## 📚 References

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [ ] `go mod tidy`
