### PR TITLE
Excludes mnd in addition to gomnd

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,10 +43,10 @@ jobs:
         run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.2
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.0
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
 
       - name: Install NilAway
-        run: go install go.uber.org/nilaway/cmd/nilaway@latest
+        run: go install go.uber.org/nilaway/cmd/nilaway@v0.0.0-20240821220108-c91e71c080b7
 
       - name: Lint
         run: make lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,6 +11,7 @@ linters:
     - godot
     - godox
     - gomnd
+    - mnd
     - lll
     - nestif
     - nilnil

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ make build-httpserver
 **Install dev dependencies**
 
 ```bash
-go install mvdan.cc/gofumpt@latest
-go install honnef.co/go/tools/cmd/staticcheck@latest
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-go install github.com/daixiang0/gci@latest
+go install mvdan.cc/gofumpt@v0.4.0
+go install honnef.co/go/tools/cmd/staticcheck@v0.4.2
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
+go install go.uber.org/nilaway/cmd/nilaway@v0.0.0-20240821220108-c91e71c080b7
 ```
 
 **Lint, test, format**


### PR DESCRIPTION
## 📝 Summary

Excludes `mnd` as only excluding `gomnd` does not work in more recent versions.

## ⛱ Motivation and Context

mnd is not cool most of the time

## 📚 References

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
