### PR TITLE
simpler http handler tests

### DIFF
--- a/httpserver/handler.go
+++ b/httpserver/handler.go
@@ -7,8 +7,8 @@ import (
 	"github.com/flashbots/go-template/metrics"
 )
 
-func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request) {
-	m := s.metricsSrv.Float64Histogram(
+func (srv *Server) handleAPI(w http.ResponseWriter, r *http.Request) {
+	m := srv.metricsSrv.Float64Histogram(
 		"request_duration_api",
 		"API request handling duration",
 		metrics.UomMicroseconds,
@@ -23,12 +23,12 @@ func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (s *Server) handleLivenessCheck(w http.ResponseWriter, r *http.Request) {
+func (srv *Server) handleLivenessCheck(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (s *Server) handleReadinessCheck(w http.ResponseWriter, r *http.Request) {
-	if !s.isReady.Load() {
+func (srv *Server) handleReadinessCheck(w http.ResponseWriter, r *http.Request) {
+	if !srv.isReady.Load() {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
 	}
@@ -36,19 +36,19 @@ func (s *Server) handleReadinessCheck(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (s *Server) handleDrain(w http.ResponseWriter, r *http.Request) {
-	if wasReady := s.isReady.Swap(false); !wasReady {
+func (srv *Server) handleDrain(w http.ResponseWriter, r *http.Request) {
+	if wasReady := srv.isReady.Swap(false); !wasReady {
 		return
 	}
 	// l := logutils.ZapFromRequest(r)
-	s.log.Info("Server marked as not ready")
-	time.Sleep(s.cfg.DrainDuration) // Give LB enough time to detect us not ready
+	srv.log.Info("Server marked as not ready")
+	time.Sleep(srv.cfg.DrainDuration) // Give LB enough time to detect us not ready
 }
 
-func (s *Server) handleUndrain(w http.ResponseWriter, r *http.Request) {
-	if wasReady := s.isReady.Swap(true); wasReady {
+func (srv *Server) handleUndrain(w http.ResponseWriter, r *http.Request) {
+	if wasReady := srv.isReady.Swap(true); wasReady {
 		return
 	}
 	// l := logutils.ZapFromRequest(r)
-	s.log.Info("Server marked as ready")
+	srv.log.Info("Server marked as ready")
 }

--- a/httpserver/handler_test.go
+++ b/httpserver/handler_test.go
@@ -94,3 +94,21 @@ func Test_Handlers_Healthcheck_Drain_Undrain(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "Healthcheck must return `Ok` after undraining")
 	}
 }
+
+func Test_Handlers_Simple(t *testing.T) {
+	// This test doesn't need the server to actually start and serve. Instead it just tests the handlers.
+	//nolint: exhaustruct
+	srv, err := New(&HTTPServerConfig{
+		Log: getTestLogger(),
+	})
+	require.NoError(t, err)
+
+	{ // Check health
+		req, err := http.NewRequest(http.MethodGet, "/readyz", nil) //nolint:goconst,nolintlint
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		srv.getRouter().ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+	}
+}


### PR DESCRIPTION
## 📝 Summary

The server doesn't need to start for handler unit-tests and it actually simplifies the tests quite a bit (see `handler_test.go`).

Also, say no to single-letter variables (renamed `s` to `srv`).

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
