### PR TITLE
Small Update on go.mod to resolve build related issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flashbots/go-template
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/flashbots/go-utils v0.6.1-0.20240610084140-4461ab748667


### PR DESCRIPTION
https://github.com/golang/go/issues/65568#issuecomment-1944131932

## 📝 Summary

There's a known and quite common build issue that I was able to reproduce. This happens when the exact toolchain version wasn't precisely specified.
`cmd/go: download go1.22 for darwin/arm64: toolchain not available
`
## ⛱ Motivation and Context

When the exact toolchain version isn't precisely specified, build commands seem to be failing.
Example: `go 1.22` instead of `go 1.22.0`

## 📚 References

- https://github.com/golang/go/issues/65568
- https://github.com/target/goalert/pull/3682
---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
